### PR TITLE
feat: add ArXiv and PubMed paper providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,13 +17,15 @@
         "openai": "^6.10.0",
         "pg": "^8.16.3",
         "uuid": "^13.0.0",
-        "winston": "^3.19.0"
+        "winston": "^3.19.0",
+        "xml2js": "^0.6.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/node": "^24.10.2",
         "@types/uuid": "^10.0.0",
+        "@types/xml2js": "^0.4.14",
         "@vitest/coverage-v8": "^4.0.18",
         "nodemon": "^3.1.11",
         "ts-node": "^10.9.2",
@@ -1082,6 +1084,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.2.tgz",
       "integrity": "sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1144,6 +1147,16 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.0.18",
@@ -2710,6 +2723,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -3070,6 +3084,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -3355,6 +3378,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3477,6 +3501,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3548,6 +3573,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3641,6 +3667,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3654,6 +3681,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -3797,6 +3825,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^24.10.2",
     "@types/uuid": "^10.0.0",
+    "@types/xml2js": "^0.4.14",
     "@vitest/coverage-v8": "^4.0.18",
     "nodemon": "^3.1.11",
     "ts-node": "^10.9.2",
@@ -39,6 +40,7 @@
     "openai": "^6.10.0",
     "pg": "^8.16.3",
     "uuid": "^13.0.0",
-    "winston": "^3.19.0"
+    "winston": "^3.19.0",
+    "xml2js": "^0.6.2"
   }
 }

--- a/src/models/database.models.ts
+++ b/src/models/database.models.ts
@@ -30,7 +30,7 @@ export interface Paper {
     year?: number;
     venue?: string;
     citation_count?: number;
-    source: 'semantic_scholar' | 'openalex' | 'crossref' | 'arxiv' | 'custom';
+    source: 'semantic_scholar' | 'openalex' | 'crossref' | 'arxiv' | 'pubmed' | 'custom';
     metadata?: Record<string, any>;
     created_at?: Date;
 }

--- a/src/providers/arxiv.provider.ts
+++ b/src/providers/arxiv.provider.ts
@@ -1,0 +1,229 @@
+import axios, { AxiosInstance, AxiosError } from 'axios';
+import { parseStringPromise } from 'xml2js';
+import { logger } from '../utils/logger';
+import {
+    PaperProvider,
+    RawPaperResult,
+    ProviderCapabilities,
+    ConcurrencyConfig,
+} from './paper-provider.interface';
+
+/*
+ArXiv API response types (parsed from XML)
+*/
+interface ArxivAuthor {
+    name: string[];
+}
+
+interface ArxivEntry {
+    id: string[];
+    title: string[];
+    summary: string[];
+    author: ArxivAuthor[];
+    published: string[];
+    updated: string[];
+    'arxiv:primary_category'?: { $: { term: string } }[];
+    category?: { $: { term: string } }[];
+    link?: { $: { href: string; rel?: string; title?: string; type?: string } }[];
+    'arxiv:doi'?: string[];
+}
+
+interface ArxivFeed {
+    feed: {
+        entry?: ArxivEntry[];
+        'opensearch:totalResults'?: string[];
+        'opensearch:startIndex'?: string[];
+        'opensearch:itemsPerPage'?: string[];
+    };
+}
+
+/*
+Clean up text from ArXiv (remove extra whitespace, newlines)
+*/
+function cleanText(text: string): string {
+    return text.replace(/\s+/g, ' ').trim();
+}
+
+/*
+Extract arXiv ID from URL
+e.g., http://arxiv.org/abs/2301.00001v1 -> 2301.00001
+*/
+function extractArxivId(url: string): string {
+    const match = url.match(/arxiv\.org\/abs\/([^\s/]+)/);
+    if (match) {
+        // Remove version suffix (v1, v2, etc.)
+        return match[1].replace(/v\d+$/, '');
+    }
+    return url;
+}
+
+export class ArxivProvider implements PaperProvider {
+    readonly name = 'arxiv';
+    readonly capabilities: ProviderCapabilities = {
+        search: true,
+        lookupByDoi: true,
+        enrichment: false,
+    };
+    // ArXiv is very generous with rate limits - 1 request per 3 seconds recommended
+    readonly concurrencyConfig: ConcurrencyConfig = {
+        maxConcurrent: 1,
+        requestsPerSecond: 0.33,
+    };
+
+    private client: AxiosInstance;
+    private readonly BASE_URL = 'http://export.arxiv.org/api';
+
+    constructor() {
+        this.client = axios.create({
+            baseURL: this.BASE_URL,
+            timeout: 30000, // ArXiv can be slow
+        });
+        logger.info('ArXiv provider initialized');
+    }
+
+    private normalizeEntry(entry: ArxivEntry): RawPaperResult {
+        const arxivUrl = entry.id?.[0] || '';
+        const arxivId = extractArxivId(arxivUrl);
+
+        // Extract DOI if present
+        const doi = entry['arxiv:doi']?.[0];
+
+        // Get the PDF link
+        const pdfLink = entry.link?.find(l => l.$?.title === 'pdf');
+        const pdfUrl = pdfLink?.$?.href;
+
+        // Extract year from published date
+        const publishedDate = entry.published?.[0];
+        const year = publishedDate ? new Date(publishedDate).getFullYear() : undefined;
+
+        // Get primary category as venue
+        const primaryCategory = entry['arxiv:primary_category']?.[0]?.$?.term;
+
+        return {
+            id: arxivId,
+            title: cleanText(entry.title?.[0] || 'Untitled'),
+            authors: (entry.author || []).map(a => ({
+                name: a.name?.[0] || 'Unknown Author',
+            })),
+            abstract: cleanText(entry.summary?.[0] || ''),
+            url: pdfUrl || arxivUrl,
+            doi,
+            year,
+            venue: primaryCategory ? `arXiv:${primaryCategory}` : 'arXiv',
+            source: 'arxiv',
+            metadata: {
+                arxivId,
+                arxivUrl,
+                pdfUrl,
+                categories: entry.category?.map(c => c.$?.term).filter(Boolean),
+                publishedDate,
+                updatedDate: entry.updated?.[0],
+            },
+        };
+    }
+
+    async search(query: string, limit: number): Promise<RawPaperResult[]> {
+        try {
+            // ArXiv search query format
+            // all: searches all fields, ti: title, au: author, abs: abstract
+            const searchQuery = `all:${query}`;
+
+            const response = await this.client.get('/query', {
+                params: {
+                    search_query: searchQuery,
+                    start: 0,
+                    max_results: Math.min(limit, 100), // ArXiv max is 100 per request
+                    sortBy: 'relevance',
+                    sortOrder: 'descending',
+                },
+            });
+
+            const parsed: ArxivFeed = await parseStringPromise(response.data);
+
+            const entries = parsed.feed?.entry || [];
+            const totalResults = parseInt(parsed.feed?.['opensearch:totalResults']?.[0] || '0', 10);
+
+            logger.debug('ArXiv search completed', {
+                query,
+                resultCount: entries.length,
+                totalCount: totalResults,
+            });
+
+            return entries
+                .filter(entry => entry && entry.title?.[0])
+                .map(entry => this.normalizeEntry(entry));
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            logger.error('ArXiv search failed', {
+                query,
+                status: axiosError.response?.status,
+                message: axiosError.message,
+            });
+            throw error;
+        }
+    }
+
+    async lookupByDoi(doi: string): Promise<RawPaperResult | null> {
+        // ArXiv doesn't have direct DOI lookup, but we can search for it
+        try {
+            const cleanDoi = doi.replace('https://doi.org/', '');
+
+            const response = await this.client.get('/query', {
+                params: {
+                    search_query: `doi:${cleanDoi}`,
+                    max_results: 1,
+                },
+            });
+
+            const parsed: ArxivFeed = await parseStringPromise(response.data);
+            const entry = parsed.feed?.entry?.[0];
+
+            if (!entry) {
+                return null;
+            }
+
+            return this.normalizeEntry(entry);
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            if (axiosError.response?.status === 404) {
+                return null;
+            }
+            logger.error('ArXiv DOI lookup failed', {
+                doi,
+                status: axiosError.response?.status,
+            });
+            throw error;
+        }
+    }
+
+    // Additional method to lookup by arXiv ID
+    async lookupByArxivId(arxivId: string): Promise<RawPaperResult | null> {
+        try {
+            // Clean the arXiv ID (remove version suffix if present)
+            const cleanId = arxivId.replace(/v\d+$/, '');
+
+            const response = await this.client.get('/query', {
+                params: {
+                    id_list: cleanId,
+                    max_results: 1,
+                },
+            });
+
+            const parsed: ArxivFeed = await parseStringPromise(response.data);
+            const entry = parsed.feed?.entry?.[0];
+
+            if (!entry) {
+                return null;
+            }
+
+            return this.normalizeEntry(entry);
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            logger.error('ArXiv ID lookup failed', {
+                arxivId,
+                status: axiosError.response?.status,
+            });
+            throw error;
+        }
+    }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,3 +2,5 @@ export * from './paper-provider.interface';
 export * from './openalex.provider';
 export * from './crossref.provider';
 export * from './semantic-scholar.provider';
+export * from './arxiv.provider';
+export * from './pubmed.provider';

--- a/src/providers/pubmed.provider.ts
+++ b/src/providers/pubmed.provider.ts
@@ -1,0 +1,330 @@
+import axios, { AxiosInstance, AxiosError } from 'axios';
+import { parseStringPromise } from 'xml2js';
+import { logger } from '../utils/logger';
+import {
+    PaperProvider,
+    RawPaperResult,
+    ProviderCapabilities,
+    ConcurrencyConfig,
+} from './paper-provider.interface';
+
+/*
+PubMed E-utilities API response types
+*/
+interface PubMedSearchResult {
+    eSearchResult: {
+        Count: string[];
+        RetMax: string[];
+        RetStart: string[];
+        IdList: { Id: string[] }[];
+    };
+}
+
+interface PubMedAuthor {
+    LastName?: string[];
+    ForeName?: string[];
+    Initials?: string[];
+    CollectiveName?: string[];
+}
+
+interface PubMedArticleId {
+    _: string;
+    $: { IdType: string };
+}
+
+interface PubMedArticle {
+    MedlineCitation: [{
+        PMID: [{ _: string }];
+        Article: [{
+            ArticleTitle: string[];
+            Abstract?: { AbstractText: (string | { _: string })[] }[];
+            AuthorList?: { Author: PubMedAuthor[] }[];
+            Journal?: {
+                Title?: string[];
+                ISOAbbreviation?: string[];
+                JournalIssue?: {
+                    PubDate?: {
+                        Year?: string[];
+                        MedlineDate?: string[];
+                    }[];
+                }[];
+            }[];
+            ELocationID?: { _: string; $: { EIdType: string } }[];
+        }];
+    }];
+    PubmedData?: [{
+        ArticleIdList?: { ArticleId: PubMedArticleId[] }[];
+    }];
+}
+
+interface PubMedFetchResult {
+    PubmedArticleSet: {
+        PubmedArticle?: PubMedArticle[];
+    };
+}
+
+/*
+Extract author name from PubMed author object
+*/
+function formatAuthorName(author: PubMedAuthor): string {
+    if (author.CollectiveName?.[0]) {
+        return author.CollectiveName[0];
+    }
+    const lastName = author.LastName?.[0] || '';
+    const foreName = author.ForeName?.[0] || author.Initials?.[0] || '';
+    return foreName ? `${foreName} ${lastName}`.trim() : lastName;
+}
+
+/*
+Extract abstract text, handling structured abstracts
+*/
+function extractAbstract(abstractData?: { AbstractText: (string | { _: string })[] }[]): string {
+    if (!abstractData?.[0]?.AbstractText) return '';
+
+    return abstractData[0].AbstractText
+        .map(text => {
+            if (typeof text === 'string') return text;
+            if (typeof text === 'object' && text._) return text._;
+            return '';
+        })
+        .filter(Boolean)
+        .join(' ')
+        .trim();
+}
+
+/*
+Extract year from PubMed date formats
+*/
+function extractYear(pubDate?: { Year?: string[]; MedlineDate?: string[] }[]): number | undefined {
+    if (!pubDate?.[0]) return undefined;
+
+    if (pubDate[0].Year?.[0]) {
+        return parseInt(pubDate[0].Year[0], 10);
+    }
+
+    // MedlineDate format: "2023 Jan-Feb" or "2023 Spring"
+    if (pubDate[0].MedlineDate?.[0]) {
+        const match = pubDate[0].MedlineDate[0].match(/^(\d{4})/);
+        if (match) return parseInt(match[1], 10);
+    }
+
+    return undefined;
+}
+
+export class PubMedProvider implements PaperProvider {
+    readonly name = 'pubmed';
+    readonly capabilities: ProviderCapabilities = {
+        search: true,
+        lookupByDoi: true,
+        enrichment: true,
+    };
+    // Rate limits: 3/sec without API key, 10/sec with key
+    readonly concurrencyConfig: ConcurrencyConfig = {
+        maxConcurrent: 3,
+        requestsPerSecond: 3,
+    };
+
+    private client: AxiosInstance;
+    private readonly BASE_URL = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils';
+    private readonly apiKey?: string;
+
+    constructor() {
+        this.apiKey = process.env.PUBMED_API_KEY;
+
+        const params: Record<string, string> = {
+            db: 'pubmed',
+            retmode: 'xml',
+        };
+
+        if (this.apiKey) {
+            params.api_key = this.apiKey;
+            this.concurrencyConfig.requestsPerSecond = 10;
+            logger.info('PubMed configured with API key - using higher rate limits');
+        } else {
+            logger.info('PubMed initialized without API key - using default rate limits');
+        }
+
+        this.client = axios.create({
+            baseURL: this.BASE_URL,
+            timeout: 30000,
+            params,
+        });
+    }
+
+    private normalizeArticle(article: PubMedArticle): RawPaperResult {
+        const citation = article.MedlineCitation[0];
+        const articleData = citation.Article[0];
+        const pubmedData = article.PubmedData?.[0];
+
+        const pmid = citation.PMID[0]._ || citation.PMID[0] as unknown as string;
+
+        // Extract DOI from article IDs
+        let doi: string | undefined;
+        const articleIds = pubmedData?.ArticleIdList?.[0]?.ArticleId || [];
+        for (const id of articleIds) {
+            if (id.$?.IdType === 'doi') {
+                doi = id._;
+                break;
+            }
+        }
+
+        // Also check ELocationID for DOI
+        if (!doi && articleData.ELocationID) {
+            const doiLocation = articleData.ELocationID.find(e => e.$?.EIdType === 'doi');
+            if (doiLocation) {
+                doi = doiLocation._;
+            }
+        }
+
+        // Extract authors
+        const authors = articleData.AuthorList?.[0]?.Author || [];
+
+        // Extract journal info
+        const journal = articleData.Journal?.[0];
+        const venue = journal?.Title?.[0] || journal?.ISOAbbreviation?.[0];
+        const year = extractYear(journal?.JournalIssue?.[0]?.PubDate);
+
+        return {
+            id: pmid,
+            title: articleData.ArticleTitle[0] || 'Untitled',
+            authors: authors
+                .map(a => ({ name: formatAuthorName(a) }))
+                .filter(a => a.name),
+            abstract: extractAbstract(articleData.Abstract),
+            url: `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`,
+            doi,
+            year,
+            venue,
+            source: 'pubmed',
+            metadata: {
+                pmid,
+                pmcid: articleIds.find(id => id.$?.IdType === 'pmc')?._,
+            },
+        };
+    }
+
+    private async fetchArticlesByIds(ids: string[]): Promise<RawPaperResult[]> {
+        if (ids.length === 0) return [];
+
+        const response = await this.client.get('/efetch.fcgi', {
+            params: {
+                id: ids.join(','),
+                rettype: 'abstract',
+            },
+        });
+
+        const parsed: PubMedFetchResult = await parseStringPromise(response.data, {
+            explicitArray: true,
+            mergeAttrs: false,
+        });
+
+        const articles = parsed.PubmedArticleSet?.PubmedArticle || [];
+        return articles.map(article => this.normalizeArticle(article));
+    }
+
+    async search(query: string, limit: number): Promise<RawPaperResult[]> {
+        try {
+            // Step 1: Search for PMIDs
+            const searchResponse = await this.client.get('/esearch.fcgi', {
+                params: {
+                    term: query,
+                    retmax: Math.min(limit, 100),
+                    sort: 'relevance',
+                },
+            });
+
+            const searchParsed: PubMedSearchResult = await parseStringPromise(searchResponse.data);
+            const ids = searchParsed.eSearchResult?.IdList?.[0]?.Id || [];
+            const totalCount = parseInt(searchParsed.eSearchResult?.Count?.[0] || '0', 10);
+
+            logger.debug('PubMed search completed', {
+                query,
+                resultCount: ids.length,
+                totalCount,
+            });
+
+            if (ids.length === 0) {
+                return [];
+            }
+
+            // Step 2: Fetch full article data
+            return await this.fetchArticlesByIds(ids);
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            logger.error('PubMed search failed', {
+                query,
+                status: axiosError.response?.status,
+                message: axiosError.message,
+            });
+            throw error;
+        }
+    }
+
+    async lookupByDoi(doi: string): Promise<RawPaperResult | null> {
+        try {
+            const cleanDoi = doi.replace('https://doi.org/', '');
+
+            // Search by DOI
+            const searchResponse = await this.client.get('/esearch.fcgi', {
+                params: {
+                    term: `${cleanDoi}[doi]`,
+                    retmax: 1,
+                },
+            });
+
+            const searchParsed: PubMedSearchResult = await parseStringPromise(searchResponse.data);
+            const ids = searchParsed.eSearchResult?.IdList?.[0]?.Id || [];
+
+            if (ids.length === 0) {
+                return null;
+            }
+
+            const results = await this.fetchArticlesByIds(ids);
+            return results[0] || null;
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            if (axiosError.response?.status === 404) {
+                return null;
+            }
+            logger.error('PubMed DOI lookup failed', {
+                doi,
+                status: axiosError.response?.status,
+            });
+            throw error;
+        }
+    }
+
+    // Lookup by PubMed ID (PMID)
+    async lookupByPmid(pmid: string): Promise<RawPaperResult | null> {
+        try {
+            const results = await this.fetchArticlesByIds([pmid]);
+            return results[0] || null;
+        } catch (error) {
+            const axiosError = error as AxiosError;
+            logger.error('PubMed PMID lookup failed', {
+                pmid,
+                status: axiosError.response?.status,
+            });
+            throw error;
+        }
+    }
+
+    // Enrich existing paper with PubMed data
+    async enrich(paper: { doi?: string }): Promise<Partial<RawPaperResult> | null> {
+        if (!paper.doi) return null;
+
+        try {
+            const result = await this.lookupByDoi(paper.doi);
+            if (!result) return null;
+
+            return {
+                abstract: result.abstract,
+                venue: result.venue,
+                year: result.year,
+                metadata: result.metadata,
+            };
+        } catch {
+            return null;
+        }
+    }
+}

--- a/src/services/agent-tools.ts
+++ b/src/services/agent-tools.ts
@@ -305,7 +305,7 @@ export class ToolExecutor {
                 newPapersFound: newPapers.length,
                 totalPapersInContext: context.papers.length,
                 searchMetadata: {
-                    providers: 'openalex + semantic_scholar',
+                    providers: 'openalex + semantic_scholar + arxiv + pubmed',
                     totalFound: result.metadata.totalFound,
                     deduplicated: result.metadata.deduplicated,
                     reranked: result.metadata.reranked,

--- a/src/services/enhanced-search.service.ts
+++ b/src/services/enhanced-search.service.ts
@@ -6,7 +6,10 @@ import { logger } from '../utils/logger';
 import {
     OpenAlexProvider,
     SemanticScholarProvider,
+    ArxivProvider,
+    PubMedProvider,
     normalizeToInternalPaper,
+    PaperProvider,
 } from '../providers';
 import { getLimiter } from '../utils/concurrency-limiter';
 
@@ -45,10 +48,14 @@ const DEFAULT_OPTIONS: EnhancedSearchOptions = {
 class EnhancedSearchService {
     private openalexProvider: OpenAlexProvider;
     private semanticScholarProvider: SemanticScholarProvider;
+    private arxivProvider: ArxivProvider;
+    private pubmedProvider: PubMedProvider;
 
     constructor() {
         this.openalexProvider = new OpenAlexProvider();
         this.semanticScholarProvider = new SemanticScholarProvider();
+        this.arxivProvider = new ArxivProvider();
+        this.pubmedProvider = new PubMedProvider();
     }
 
     /**
@@ -100,6 +107,14 @@ class EnhancedSearchService {
                     // Semantic Scholar
                     searchPromises.push(
                         this.searchProvider(this.semanticScholarProvider, variant, opts.limit!)
+                    );
+                    // ArXiv
+                    searchPromises.push(
+                        this.searchProvider(this.arxivProvider, variant, opts.limit!)
+                    );
+                    // PubMed
+                    searchPromises.push(
+                        this.searchProvider(this.pubmedProvider, variant, opts.limit!)
                     );
                 }
 
@@ -189,7 +204,7 @@ class EnhancedSearchService {
      * Search a single provider, normalize results, and save to DB
      */
     private async searchProvider(
-        provider: OpenAlexProvider | SemanticScholarProvider,
+        provider: PaperProvider,
         query: string,
         limit: number
     ): Promise<Paper[]> {

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -8,10 +8,12 @@ import {
     OpenAlexProvider,
     CrossrefProvider,
     SemanticScholarProvider,
+    ArxivProvider,
+    PubMedProvider,
 } from '../providers';
 import { getLimiter } from '../utils/concurrency-limiter';
 
-type ProviderName = 'openalex' | 'semantic_scholar' | 'crossref';
+type ProviderName = 'openalex' | 'semantic_scholar' | 'crossref' | 'arxiv' | 'pubmed';
 
 class SearchService {
     private providers: Map<ProviderName, PaperProvider>;
@@ -23,6 +25,8 @@ class SearchService {
         this.providers.set('openalex', new OpenAlexProvider());
         this.providers.set('semantic_scholar', new SemanticScholarProvider());
         this.providers.set('crossref', new CrossrefProvider());
+        this.providers.set('arxiv', new ArxivProvider());
+        this.providers.set('pubmed', new PubMedProvider());
 
         // Select primary provider from env
         const primaryName = (process.env.PRIMARY_PAPER_PROVIDER || 'openalex') as ProviderName;


### PR DESCRIPTION

  ## Summary
  - Add ArXiv provider for preprints (physics, math, CS, quantitative biology)
  - Add PubMed provider for biomedical literature (NCBI)
  - Integrate both providers into enhanced search service

  ## Changes
  | File | Description |
  |------|-------------|
  | `src/providers/arxiv.provider.ts` | ArXiv API integration |
  | `src/providers/pubmed.provider.ts` | PubMed E-utilities API integration |
  | `src/providers/index.ts` | Export new providers |
  | `src/services/search.service.ts` | Register providers |
  | `src/services/enhanced-search.service.ts` | Multi-provider parallel search |
  | `src/services/agent-tools.ts` | Update provider metadata |
  | `src/models/database.models.ts` | Add 'pubmed' to source type |
  | `package.json` | Add xml2js dependency |

  ## Provider Features
  | Provider | Search | DOI Lookup | Enrichment | Rate Limit |
  |----------|--------|------------|------------|------------|
  | ArXiv | ✅ | ✅ | ❌ | 0.33/sec |
  | PubMed | ✅ | ✅ | ✅ | 3-10/sec |

  ## Test Plan
  - [x] Build passes
  - [x] Direct provider tests pass
  - [x] Server starts with all 4 providers initialized